### PR TITLE
Fix require, add uid and last_name

### DIFF
--- a/lib/omniauth-classlink.rb
+++ b/lib/omniauth-classlink.rb
@@ -1,1 +1,1 @@
-require 'omniauth/classlink'
+require 'omniauth/class_link'

--- a/lib/omniauth/class_link.rb
+++ b/lib/omniauth/class_link.rb
@@ -1,2 +1,2 @@
-require 'omniauth/classlink/version'
-require 'omniauth/strategies/classlink'
+require 'omniauth/class_link/version'
+require 'omniauth/strategies/class_link'

--- a/lib/omniauth/strategies/class_link.rb
+++ b/lib/omniauth/strategies/class_link.rb
@@ -13,6 +13,10 @@ module OmniAuth
       option :fields, [:email, :profile]
       option :uid_field, 'UserId'
 
+      uid do
+        raw_info[options.uid_field.to_s]
+      end
+
       def authorize_params
         super.tap do |params|
           params[:scope] = [:email, :profile]
@@ -23,6 +27,7 @@ module OmniAuth
       info do
         {
           first_name: raw_info['FirstName'],
+          last_name: raw_info['LastName'],
           district_id: raw_info['TenantId'],
           classlink_id: raw_info['UserId'],
           external_id: raw_info['SourcedId'],


### PR DESCRIPTION
With the [renaming which happened in ad54b55c345393e52a717724fc35fcb30dfe21ce](ad54b55c345393e52a717724fc35fcb30dfe21ce) I was getting exceptions when trying to start rails, it was falling over with

```
bundle/ruby/2.6.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `require': cannot load such file -- omniauth/classlink (LoadError)
```

This PR changes the require to match the renamed filenames.

This also adds in the `last_name` field to the info hash, and correctly returns the uid field which was previously missing.