### PR TITLE
Add email into the info hash.

### DIFF
--- a/lib/omniauth/strategies/class_link.rb
+++ b/lib/omniauth/strategies/class_link.rb
@@ -31,7 +31,8 @@ module OmniAuth
           district_id: raw_info['TenantId'],
           classlink_id: raw_info['UserId'],
           external_id: raw_info['SourcedId'],
-          role: raw_info['Role']
+          role: raw_info['Role'],
+          email: raw_info['Email']
         }
       end
 


### PR DESCRIPTION
The Auth Hash says that we should provide the email in the info hash if
we can. See https://github.com/omniauth/omniauth/wiki/Auth-Hash-Schema
for more details.