### PR TITLE
feat: [CSA-4488] Allow extra scopes to be passed in  to initializer

### DIFF
--- a/lib/omniauth/strategies/class_link.rb
+++ b/lib/omniauth/strategies/class_link.rb
@@ -19,7 +19,7 @@ module OmniAuth
 
       def authorize_params
         super.tap do |params|
-          params[:scope] = [:email, :profile]
+          params[:scope] = (params[:scope] || []).union([:email, :profile])
           params[:response_type] = :code
         end
       end


### PR DESCRIPTION
## Description

This just allows you to pass in extra scopes as `auth_params` in the initializer for the ClassLink Omniauth strategy.
The way it is set up it will always only ask for the `email` and `profile` scopes, but for our use case we need to also request the rostering scope. 

With this change, the default scopes (`email`, and `profile`) will always be request, but if any additional scopes are passed in in the `auth_params`, they will be appended to the list of scopes that get requested from ClassLink. 

Thanks to @GURVARINDER for helping me with this. 
